### PR TITLE
keep tracked view's in local transaction view to avoid constant cloni…

### DIFF
--- a/src/main/java/org/jacis/store/TrackedViewTransactionLocal.java
+++ b/src/main/java/org/jacis/store/TrackedViewTransactionLocal.java
@@ -1,0 +1,27 @@
+package org.jacis.store;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jacis.trackedviews.TrackedView;
+
+class TrackedViewTransactionLocal<TV, K> {
+  final private TrackedView<TV> trackedView;
+  final private Map<StoreEntryTxView<K, TV, ?>, TV> lastEntries = new HashMap<>();
+
+  TrackedViewTransactionLocal(TrackedView<TV> trackedView) {
+    this.trackedView = trackedView;
+  }
+
+  void trackModification(TV origValue, TV value, StoreEntryTxView<K, TV, ?> entry) {
+    TV lastUpdatedValue = lastEntries.get(entry);
+    trackedView.trackModification(lastUpdatedValue == null ? origValue : lastUpdatedValue, value);
+    @SuppressWarnings("unchecked")
+    TV clone = (TV) entry.getCommittedEntry().getStore().getObjectAdapter().cloneTxView2Committed(value);
+    lastEntries.put(entry, clone);
+  }
+
+  TrackedView<TV> getTrackedView() {
+    return trackedView;
+  }
+}

--- a/src/test/java/org/jacis/trackedview/TransactionLocalTrackedViewTest.java
+++ b/src/test/java/org/jacis/trackedview/TransactionLocalTrackedViewTest.java
@@ -1,0 +1,43 @@
+package org.jacis.trackedview;
+
+import static org.junit.Assert.*;
+
+import org.jacis.container.JacisContainer;
+import org.jacis.integration.JacisStoreIntegrationTest;
+import org.jacis.store.JacisStore;
+import org.jacis.testhelper.JacisTestHelper;
+import org.jacis.testhelper.TestObject;
+import org.jacis.testhelper.TrackedTestView;
+import org.jacis.trackedviews.TrackedView;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TransactionLocalTrackedViewTest {
+
+  private static final Logger log = LoggerFactory.getLogger(JacisStoreIntegrationTest.class);
+
+  @Test
+  public void testModificationTrackingInTransaction() {
+    JacisTestHelper testHelper = new JacisTestHelper();
+    JacisStore<String, TestObject> store = testHelper.createTestStoreWithCloning();
+    JacisContainer container = store.getContainer();
+    container.withLocalTx(() -> {
+      store.update("1", new TestObject("A1").setValue(5));
+    });
+    TrackedView<TestObject> view = new TrackedTestView();
+    store.getTrackedViewRegistry().registerTrackedView(view);
+    assertEquals(5, store.getTrackedViewRegistry().getView(TrackedTestView.class).getSum());
+
+    container.withLocalTx(() -> {
+      TestObject o = store.get("1");
+      o.setValue(3);
+      store.update("1", o);
+      assertEquals(3, store.getTrackedViewRegistry().getView(TrackedTestView.class).getSum());
+      o.setValue(4);
+      store.update("1", o);
+      assertEquals(4, store.getTrackedViewRegistry().getView(TrackedTestView.class).getSum());
+    });
+    assertEquals(4, store.getTrackedViewRegistry().getView(TrackedTestView.class).getSum());
+  }
+}


### PR DESCRIPTION
In order to avoid cloning all the time a trackedview is accessed, keep it in the transaction view and track modifications immediately. 
